### PR TITLE
Update Dockerfile, metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,9 @@
 {
-    "title": "phytoplankton species classifier",
+    "title": "Phytoplankton species classifier (VLIZ)",
     "summary": "",
     "description": [
-        "phytoplankton species classifier is an application using the DEEPaaS API.\n",
-        "Write additional information for your users (how to predict, how to retrain,",
-        "dataset description, training description, etc)."
+        "Phytoplankton species classifier is an application to classify phytoplankton, features DEEPaaS API.\n",
+        "Provided by VLIZ (Flanders Marine Institute)"
     ],
     "keywords": [
         "docker",


### PR DESCRIPTION
- remove (deprecated) Onedata
- installation of JupyterLab happens through deep-start anyway (thus, removed)
- a few other removal of commented lines
- add (VLIZ) to the title of the application to distinguish with similar module